### PR TITLE
8313 fork modify ack

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gocloud.dev
+module github.com/retailnext/go-cloud
 
 go 1.12
 

--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -44,7 +44,8 @@
 //  - Topic: *raw.PublisherClient
 //  - Subscription: *raw.SubscriberClient
 //  - Message.BeforeSend: *pb.PubsubMessage
-//  - Message: *pb.PubsubMessage
+//  - Message.AfterSend: *string for the pb.PublishResponse.MessageIds entry corresponding to the message.
+//  - Message: *pb.PubsubMessage, *pb.ReceivedMessage
 //  - Error: *google.golang.org/grpc/status.Status
 package gcppubsub // import "gocloud.dev/pubsub/gcppubsub"
 
@@ -425,26 +426,33 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 
 	ms := make([]*driver.Message, 0, len(resp.ReceivedMessages))
 	for _, rm := range resp.ReceivedMessages {
+		rm := rm
 		rmm := rm.Message
 		m := &driver.Message{
-			Body:     rmm.Data,
-			Metadata: rmm.Attributes,
-			AckID:    rm.AckId,
-			AsFunc:   messageAsFunc(rmm),
+			LoggableID: rmm.MessageId,
+			Body:       rmm.Data,
+			Metadata:   rmm.Attributes,
+			AckID:      rm.AckId,
+			AsFunc:     messageAsFunc(rmm, rm),
 		}
 		ms = append(ms, m)
 	}
 	return ms, nil
 }
 
-func messageAsFunc(pm *pb.PubsubMessage) func(interface{}) bool {
+func messageAsFunc(pm *pb.PubsubMessage, rm *pb.ReceivedMessage) func(interface{}) bool {
 	return func(i interface{}) bool {
-		p, ok := i.(**pb.PubsubMessage)
-		if !ok {
-			return false
+		ip, ok := i.(**pb.PubsubMessage)
+		if ok {
+			*ip = pm
+			return true
 		}
-		*p = pm
-		return true
+		rp, ok := i.(**pb.ReceivedMessage)
+		if ok {
+			*rp = rm
+			return true
+		}
+		return false
 	}
 }
 

--- a/pubsub/gcppubsub/gcppubsub_test.go
+++ b/pubsub/gcppubsub/gcppubsub_test.go
@@ -255,6 +255,10 @@ func (gcpAsTest) MessageCheck(m *pubsub.Message) error {
 	if !m.As(&ppm) {
 		return fmt.Errorf("cast failed for %T", &ppm)
 	}
+	var prm *pubsubpb.ReceivedMessage
+	if !m.As(&prm) {
+		return fmt.Errorf("cast failed for %T", &prm)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This forked is to work-around the problem of needed to upgrade GRPC in our
storenet. The upstream fixed #3131 is need for CLOUD-8313 but requires GRPC
upgrade which is a bigger effort, CLOUD-7492.
This PR cherry-pick commit #3131 to our existing gocloud.dev@333a9b0 (master
HEAD)

Once, CLOUD-7492 completed, we should remove this fork to use upstream's repo.