### PR TITLE
update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-module gocloud.dev
+module github.com/retailnext/go-cloud
 
 go 1.12
 


### PR DESCRIPTION
This forked is to work-around the problem of needed to upgrade GRPC in our
storenet. The upstream fixed #3131 is need for CLOUD-8313 but requires GRPC
upgrade which is a bigger effort recorded here, CLOUD-7492.
