### PR TITLE
Remove unknown field.

### DIFF
--- a/pubsub/gcppubsub/gcppubsub.go
+++ b/pubsub/gcppubsub/gcppubsub.go
@@ -429,11 +429,10 @@ func (s *subscription) ReceiveBatch(ctx context.Context, maxMessages int) ([]*dr
 		rm := rm
 		rmm := rm.Message
 		m := &driver.Message{
-			LoggableID: rmm.MessageId,
-			Body:       rmm.Data,
-			Metadata:   rmm.Attributes,
-			AckID:      rm.AckId,
-			AsFunc:     messageAsFunc(rmm, rm),
+			Body:     rmm.Data,
+			Metadata: rmm.Attributes,
+			AckID:    rm.AckId,
+			AsFunc:   messageAsFunc(rmm, rm),
 		}
 		ms = append(ms, m)
 	}


### PR DESCRIPTION
This field was added for logging purpose, issue 2994. I want to keep this forked
as close as the working hash, 333a9b0c16f6, with minimal changes. So, I decided
to fix it instead of cherry-pick another commit.